### PR TITLE
Fix xtask errors after upgrading

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -34,8 +34,8 @@ fn main() -> Result<(), anyhow::Error> {
         Some(("ci", _)) => tasks::ci(),
         Some(("docs", _)) => tasks::docs(),
         Some(("powerset", _)) => tasks::powerset(),
-        Some(("bloat-deps", _)) => tasks::bloat_deps(),
-        Some(("bloat-time", _)) => tasks::bloat_time(),
+        Some(("bloat-deps", _)) => tasks::bloat_deps("backpack"),
+        Some(("bloat-time", _)) => tasks::bloat_time("backpack"),
         _ => unreachable!("unreachable branch"),
     };
     res


### PR DESCRIPTION
Fix "this function takes 1 argument but 0 arguments were supplied" error.